### PR TITLE
Size options

### DIFF
--- a/Dynamic Reposition.sketchplugin
+++ b/Dynamic Reposition.sketchplugin
@@ -10,7 +10,7 @@ var contentLayers = [];
 
 // Puts all layers and groups except the background in an array.
 function getContent() {
-	var group = selection[0].layers();	
+	var group = selection[0].layers();
 
 	for( var i=0; i<[group count]; i++) {
 
@@ -29,18 +29,19 @@ function positionContent() {
 
 	var margin = [];
 
-	
+
 	// Position all layers
 	for( var i=0; i<contentLayers.length; i++ ) {
 		var currentLayer = contentLayers[i];
-		var currW = [currentLayer frame].width());
-		var currH = [currentLayer frame].height();
 		var margin = getMargins([currentLayer name]);
 
 		var top = null;
 		var right = null;
 		var bottom = null;
 		var left = null;
+		var width = null;
+		var height = null;
+		var fontSize = null;
 
 		// get format offset
 		for( var j=0; j<margin.length; j+=2 ) {
@@ -48,51 +49,81 @@ function positionContent() {
 			switch(margin[j].toLowerCase()) {
 				case 't':
 				case 'top':
-					top = Number(margin[j+1]);		
+					top = Number(margin[j+1]);
 					break;
 
 				case 'r':
-				case 'right': 
-					right = Number(margin[j+1]);			
+				case 'right':
+					right = Number(margin[j+1]);
 					break;
-				
+
 				case 'b':
 				case 'bottom':
-					bottom = Number(margin[j+1]);		
+					bottom = Number(margin[j+1]);
 					break;
 
 				case 'l':
 				case 'left':
 					left = Number(margin[j+1]);
-					break;					
+					break;
+
+				case 'w':
+				case 'width':
+					width = Number(margin[j+1]);
+					break;
+
+				case 'h':
+				case 'height':
+					height = Number(margin[j+1]);
+					break;
+
+				case 'fs':
+				case 'fontSize':
+					fontSize = Number(margin[j+1]);
+					break;
 			}
 		}
-		
+
+		//check if font and has a size set
+		if (currentLayer.className() == "MSTextLayer" && fontSize != null){
+			currentLayer.setFontSize(fontSize);
+			currentLayer.frame().height = currentLayer.lineSpacing();
+		}
+
 		// set new width
-		if( right != null && left != null ) currentLayer.frame().width = bgW - (left + right);
+		if( right != null && left != null && width != null ) currentLayer.frame().width = bgW - (left + right);
+
 		// set new height
-		if( top != null && bottom != null ) currentLayer.frame().height = bgH - (top + bottom);
+		if( top != null && bottom != null && height != null ) currentLayer.frame().height = bgH - (top + bottom);
+
+		// resize layer if size is set
+		if( width  != null )currentLayer.frame().width = width;
+		if( height != null) currentLayer.frame().height = height;
+
+		var currW = [currentLayer frame].width());
+		var currH = [currentLayer frame].height();
 
 		// position layer
 		if( bottom != null ) currentLayer.frame().y = (bgY + bgH) - (bottom + currH);
 		if( top    != null ) currentLayer.frame().y = bgY + top;
 		if( right  != null ) currentLayer.frame().x = (bgX + bgW) - (right + currW);
 		if( left   != null ) currentLayer.frame().x = bgX + left;
+
 		// align middle
 		if( top == null && bottom == null ) currentLayer.frame().y = (bgY + bgH)*.5 - currH*.5;
 		// align center
 		if( right == null && left == null ) currentLayer.frame().x = ((bgX + bgW)*.5) - (currW*.5);
-		
+
 	}
-	[doc showMessage:"The content have been repositioned"]
+	[doc showMessage:"The content has been repositioned."]
 }
 
 function getMargins(name) {
-	var possibleDividers = [' t:',' top:',' r:',' right:',' b:',' bottom:',' l:',' left:'];
+	var possibleDividers = [' t:',' top:',' r:',' right:',' b:',' bottom:',' l:',' left:', ' width:', ' w:', ' fontSize:', ' fs:'];
 	var index = 0;
 
 	for(var i=0; i<possibleDividers.length; i++) {
-		
+
 		if(name.toLowerCase().indexOf(possibleDividers[i]) != -1) {
 			index = name.indexOf(possibleDividers[i]);
 			break;
@@ -108,10 +139,10 @@ function findBackgroundByName(){
 	var group = selection[0].layers();
 
 	for( var i=0; i<[group count]; i++) {
-		
+
 		if(group.array()[i].name() == bgName) {
 			return group.array()[i];
-		} 
+		}
 	}
 }
 
@@ -124,7 +155,7 @@ function findBackgroundBySize(){
 	for( var i=0; i<[group count]; i++) {
 		var w = group.array()[i].frame().width();
 		var h = group.array()[i].frame().height();
-		
+
 		if( w > maxWidth && h > maxHeight ){
 			maxWidth = w;
 			maxHeight = h;
@@ -136,16 +167,13 @@ function findBackgroundBySize(){
 
 
 // Needs to have a group selected to start the script.
-if( [selection count] > 0 )
-{
+if( [selection count] > 0 ){
 	background = findBackgroundByName();
 	if( background == null ) { background = findBackgroundBySize();	}
 
 	getContent();
 	positionContent();
-} 
-else 
-{
+} else {
 	alert("Nothing selected","Please select a group");
 }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First of all you need to have [Sketch 3](http://bohemiancoding.com/sketch/) inst
 ###Use Sketch Toolbox (recommended)
 Use [Sketch Toolbox](http://sketchtoolbox.com/) to search for `Dynamic Reposition` and click install.
 
-###Install manually 
+###Install manually
 
 1. [Download the latest release](https://github.com/AntonStrand/dynamic-reposition/releases) and open it
 2. Navigate the Sketch menu bar to `Plugins ▸ Reveal Plugins Folder`
@@ -23,13 +23,13 @@ Use [Sketch Toolbox](http://sketchtoolbox.com/) to search for `Dynamic Repositio
 ##How to use the plugin
 
 1. Select a layer you want to use as an background and rename it to "*background*".
-2. Give all the other layers/groups inside of the same group margin properties (see below). 
+2. Give all the other layers/groups inside of the same group margin properties (see below).
 3. Select the main group.
 4. Use the plugin by pressing `cmd p` or select `plugins ▸ Dynamic reposition`
 
-*The shortcut can easily be changed by changing the first row in the plugin* 
+*The shortcut can easily be changed by changing the first row in the plugin*
 
-You'll need a background. You can either create a layer or a group called "background" or it will take the largest layer in the group and use it as the background. 
+You'll need a background. You can either create a layer or a group called "background" or it will take the largest layer in the group and use it as the background.
 
 
 ###Set properties
@@ -37,14 +37,19 @@ You'll need a background. You can either create a layer or a group called "backg
 You set the margin in the name of the layer. For instance, `My button t:10:l:50` will position the button `top: 10px` and `left: 50px`.
 
 **You can set properties for:**
- * top `t:` or `top:` 
+ * top `t:` or `top:`
  * right `r:` or `right:`
- * bottom	`b:` or `bottom:` 
+ * bottom	`b:` or `bottom:`
  * left `l:` or `left:`
 
 By not setting any properties for `top` or `bottom` it will be placed in the middle of the background. If you don't set any properties for `left` and `right` it will be centered.
 
 By setting properties for both `top` and `bottom` or/and `left` and `right` the object will be stretched out to keep the right distance to the background. Make sure to _not_ have locked proportions otherwise it wont work as it is supposed to. To have more control over resizing objects make sure to try out my other plugin, [Sketch Resize](https://github.com/AntonStrand/Sketch-Resize)
+
+**You can set size properties for:**
+ * width `w:` or `width:`
+ * height `h:` or `height:`
+ * fontSize `fs:` or `fontSize:`
 
 **_Make sure to seperate each property with a semicolon_** `:`
 


### PR DESCRIPTION
Added options for width, height, and fontSize. This helps when resizing the group with sublayers like circles or text. Adding a circle like a profile pic to a group with title "profile l:16:w:48:h:48" will keep the size of the profile pic to 48x48 while centering it vertically and left:16px when resizing the parent group.

Font size works similarly by defining the size font you want instead of letting it go all crazy scaled when resizing the group.
